### PR TITLE
Extract bit buffer code to separate reader and writer.

### DIFF
--- a/examples/receive-encoded/receive-encoded.ino
+++ b/examples/receive-encoded/receive-encoded.ino
@@ -1,7 +1,7 @@
 /* receive-encoded.ino Example sketch for Quest IR Library
  * This example will receive IR signals and decode them
  * based on the Quest IR format.
- * 
+ *
  * Note: Update PIN_IR_RECEIVER to the pin connected to
  * an IR receiver such as the Vishay TSOP38238.
  */
@@ -24,19 +24,25 @@ void setup()
 void loop()
 {
     // check to see if the receiver decoded a signal
-    if (irReceiver.hasData())
+    if (irReceiver.hasSignal())
     {
         // data was received, dump it to Serial
         irReceiver.printRawSignal();
 
         // output the received bits
         Serial.print("Received ");
-        Serial.print(irReceiver.bitsReceived);
+        Serial.print(irReceiver.decodedBitCount);
         Serial.print(" bits: ");
 
-        for (int i = 0; i < irReceiver.bitsReceived / 8; i++)
+        uint8_t bytesWithData = irReceiver.decodedBitCount / 8;
+        if (irReceiver.decodedBitCount % 8 > 0)
         {
-            uint8_t bits = irReceiver.readBits(8);
+            bytesWithData++;
+        }
+
+        for (int i = 0; i < bytesWithData; i++)
+        {
+            uint8_t bits = irReceiver.decodedBits[i];
             Serial.print(bits, BIN);
             Serial.print(" ");
         }

--- a/examples/send-encoded/send-encoded.ino
+++ b/examples/send-encoded/send-encoded.ino
@@ -1,12 +1,16 @@
 /* send-encoded.cpp Example sketch for Quest IR Library
  * This example will send encoded data over IR.
- * 
- * Note: For ItsyBitsy M0, the IR LED is set to pin 4 for 
+ *
+ * Note: For ItsyBitsy M0, the IR LED is set to pin 4 for
  * compatibility with the Quest stack running on a single MCU.
  */
 #include <Quest_IR_Transmitter.h>
+#include <Quest_IR_BitWriter.h>
 
 Quest_IR_Transmitter irTransmitter;
+Quest_IR_BitWriter irBitWriter = Quest_IR_BitWriter(irTransmitter.encodedBits, QIR_BUFFER_SIZE);
+
+int8_t patternToSend = 0;
 
 void setup()
 {
@@ -17,15 +21,30 @@ void setup()
 
 void loop()
 {
-    irTransmitter.clearBits();
-    irTransmitter.addBits('H', 8);
-    irTransmitter.addBits('I', 8);
-    irTransmitter.addBits(7, 3);
-    irTransmitter.addBits(1, 3);
-    irTransmitter.addBits(1, 2);
+    irBitWriter.reset();
+
+    switch (patternToSend)
+    {
+    case 0:
+        Serial.println("---- Sending byte aligned packet (will also send padding) ----");
+        irBitWriter.writeBits('H', 8);
+        irBitWriter.writeBits('I', 8);
+        break;
+    case 1:
+        Serial.println("---- Sending non-byte aligned packet ----");
+        irBitWriter.writeBits(0xABC, 12);
+        break;
+    default:
+        patternToSend = -1; // it'll be incremented to 0 right after this switch
+        Serial.println("---- Sending less than one byte packet (odd bits for no padding) ----");
+        irBitWriter.writeBits(0b00010101, 5);
+        break;
+    }
+
+    patternToSend++;
 
     unsigned long startTimeMs = millis();
-    irTransmitter.sendBits();
+    irTransmitter.sendBits(irBitWriter.bitsWritten());
     unsigned long transmitTime = millis() - startTimeMs;
 
     Serial.print("Bits sent in ");

--- a/src/Quest_IR_BitBuffer.cpp
+++ b/src/Quest_IR_BitBuffer.cpp
@@ -1,0 +1,11 @@
+#include "Quest_IR_BitBuffer.h"
+
+void printBinaryArray(uint8_t *buffer, uint16_t length)
+{
+    for (uint8_t i = 0; i < length; i++)
+    {
+        Serial.print(buffer[i], BIN);
+        Serial.print(F(" "));
+    }
+    Serial.println();
+}

--- a/src/Quest_IR_BitBuffer.h
+++ b/src/Quest_IR_BitBuffer.h
@@ -1,0 +1,21 @@
+/* Quest_IR_BitBuffer.h Quest IR Bit Buffer Library
+ * Utilities to read from and write bits to a byte buffer.
+ *
+ * See Quest_IR_BitReader.h to read bits and Quest_IR_BitWriter.h to
+ * write bits.
+ *
+ * Format:
+ * Reading and writing start at byte 0 in the buffer. Within each byte, bits are
+ * read and written from left-most bit to right-most bit.
+ */
+#ifndef quest_ir_bitbuffer_h
+#define quest_ir_bitbuffer_h
+
+#include <Arduino.h>
+
+#define QIR_FIRST_BIT 0b10000000
+#define QIR_FIRST_BIT_OF_INT 0x80000000
+
+void printBinaryArray(uint8_t *buffer, uint16_t length);
+
+#endif

--- a/src/Quest_IR_BitReader.cpp
+++ b/src/Quest_IR_BitReader.cpp
@@ -1,0 +1,86 @@
+#include "Quest_IR_BitReader.h"
+
+Quest_IR_BitReader::Quest_IR_BitReader(uint8_t *buffer, uint8_t bufferLength)
+{
+    this->buffer = buffer;
+    this->bufferLength = bufferLength;
+
+    reset(0);
+}
+
+void Quest_IR_BitReader::reset(uint16_t bitsAvailable)
+{
+    // bits available should never exceed buffer size
+    bitCount = min(bitsAvailable, bufferLength * 8);
+    bitPosition = 0;
+    bufferPosition = 0;
+    bitMask = QIR_FIRST_BIT;
+}
+
+uint16_t Quest_IR_BitReader::bitsRemaining()
+{
+    return bitCount - bitPosition;
+}
+
+bool Quest_IR_BitReader::readBit()
+{
+    if (bitPosition >= bitCount)
+    {
+        // already read all available bits
+        return 0;
+    }
+
+    bool bit = buffer[bufferPosition] & bitMask;
+    bitMask >>= 1;
+    if (bitMask == 0)
+    {
+        // no more bits in the current byte, move to the next
+        bufferPosition++;
+        bitMask = QIR_FIRST_BIT;
+    }
+    bitPosition++;
+
+    return bit;
+}
+
+uint32_t Quest_IR_BitReader::readBits(uint8_t bitsToRead)
+{
+    if (bitPosition >= bitCount)
+    {
+        // already read all available bits
+        return 0;
+    }
+
+    // do not read more bits than available
+    if (bitPosition + bitsToRead > bitCount)
+    {
+        bitsToRead = bitCount - bitPosition;
+    }
+
+    uint32_t readBits = 0;
+    uint8_t bufferByte = buffer[bufferPosition];
+
+    for (uint16_t i = 0; i < bitsToRead; i++)
+    {
+        // shift the read bits, and set the next bit from the buffer
+        readBits <<= 1;
+        if (bufferByte & bitMask)
+        {
+            readBits |= 1;
+        }
+
+        // move to the next bit in the buffer
+        bitMask >>= 1;
+        if (bitMask == 0)
+        {
+            // the current buffer has been read, move to the next
+            bufferPosition++;
+            bufferByte = buffer[bufferPosition];
+            bitMask = QIR_FIRST_BIT;
+        }
+    }
+
+    bitPosition += bitsToRead;
+
+    return readBits;
+}

--- a/src/Quest_IR_BitReader.h
+++ b/src/Quest_IR_BitReader.h
@@ -1,0 +1,30 @@
+/* Quest_IR_BitReader.h Quest IR Bit Reader Library
+ * Reads one or more bits from a byte buffer.
+ */
+#ifndef quest_ir_bitreader_h
+#define quest_ir_bitreader_h
+
+#include "Quest_IR_BitBuffer.h"
+
+class Quest_IR_BitReader
+{
+public:
+  Quest_IR_BitReader(uint8_t *buffer, uint8_t bufferLength);
+
+  uint16_t bitCount;
+  uint16_t bitPosition;
+
+  void reset(uint16_t bitsAvailable);
+  uint16_t bitsRemaining();
+
+  bool readBit();
+  uint32_t readBits(uint8_t bitsToRead);
+
+private:
+  uint8_t *buffer;
+  uint8_t bufferLength;
+  uint8_t bufferPosition;
+  uint8_t bitMask;
+};
+
+#endif

--- a/src/Quest_IR_BitWriter.cpp
+++ b/src/Quest_IR_BitWriter.cpp
@@ -1,0 +1,79 @@
+#include "Quest_IR_BitWriter.h"
+
+Quest_IR_BitWriter::Quest_IR_BitWriter(uint8_t *buffer, uint8_t bufferLength)
+{
+    this->buffer = buffer;
+    this->bufferLength = bufferLength;
+
+    reset();
+}
+
+void Quest_IR_BitWriter::reset()
+{
+    bitPosition = 0;
+    bufferPosition = 0;
+    bitMask = QIR_FIRST_BIT;
+    memset(buffer, 0, bufferLength);
+}
+
+uint16_t Quest_IR_BitWriter::bitsWritten()
+{
+    return bitPosition;
+}
+
+uint16_t Quest_IR_BitWriter::bitsRemaining()
+{
+    return (bufferLength << 3) - bitPosition;
+}
+
+bool Quest_IR_BitWriter::writeBit(bool bit)
+{
+    // make sure there is enough room in the buffer
+    if (bitsRemaining() == 0)
+    {
+        return false;
+    }
+
+    writeBitInternal(bit);
+
+    return true;
+}
+
+bool Quest_IR_BitWriter::writeBits(uint32_t bits, uint8_t bitsToWrite)
+{
+    // make sure there is enough room in the buffer
+    if (bitsToWrite >= bitsRemaining())
+    {
+        return false;
+    }
+
+    // shift the bits so the first bit to write is left-most
+    bits <<= (32 - bitsToWrite);
+
+    // add each bit to the buffer
+    for (uint16_t i = 0; i < bitsToWrite; i++)
+    {
+        writeBitInternal(bits & QIR_FIRST_BIT_OF_INT);
+        bits <<= 1;
+    }
+
+    return true;
+}
+
+inline void Quest_IR_BitWriter::writeBitInternal(bool bit)
+{
+    // update the bit in the buffer, assume buffer is all 0's so only need to write 1's
+    if (bit)
+    {
+        buffer[bufferPosition] = buffer[bufferPosition] | bitMask;
+    }
+
+    bitMask >>= 1;
+    if (bitMask == 0)
+    {
+        // no more bits in the current byte, move to the next
+        bufferPosition++;
+        bitMask = QIR_FIRST_BIT;
+    }
+    bitPosition++;
+}

--- a/src/Quest_IR_BitWriter.h
+++ b/src/Quest_IR_BitWriter.h
@@ -1,0 +1,32 @@
+/* Quest_IR_BitWriter.h Quest IR Bit Writer Library
+ * Writes one or more bits to a byte buffer.
+ */
+#ifndef quest_ir_bitwriter_h
+#define quest_ir_bitwriter_h
+
+#include "Quest_IR_BitBuffer.h"
+
+class Quest_IR_BitWriter
+{
+  public:
+    Quest_IR_BitWriter(uint8_t *buffer, uint8_t bufferLength);
+
+    uint16_t bitPosition;
+
+    void reset();
+    uint16_t bitsWritten();
+    uint16_t bitsRemaining();
+
+    bool writeBit(bool bit);
+    bool writeBits(uint32_t bits, uint8_t bitsToWrite);
+
+  private:
+    uint8_t *buffer;
+    uint8_t bufferLength;
+    uint8_t bufferPosition;
+    uint8_t bitMask;
+
+    void writeBitInternal(bool bit);
+};
+
+#endif

--- a/src/Quest_IR_Format.h
+++ b/src/Quest_IR_Format.h
@@ -1,15 +1,15 @@
 /* Quest_IR_Format.h Quest IR Format definitions
  * These values are used by the receiver and transmitter Quest IR libraries.
- * 
+ *
  * Encoding Notes:
  * Each IR signal contains a header mark and space, followed by the encoded
- * data bits. Many IR protocols only encode bits in either the mark or the 
+ * data bits. Many IR protocols only encode bits in either the mark or the
  * space, but the Quest IR format encodes bits in pulse width of both the
  * mark and space, halving the transmission size.
  * If the number of bits sent is even, an addition padding mark will be sent
  * for IR signal compatibility that will be ignored by the receiver.
  * Pulse timing is not 100% accurate, so if a pulse is less than the expected
- * value + QIR_ERROR_MARGIN, then it will still count as that value. For 
+ * value + QIR_ERROR_MARGIN, then it will still count as that value. For
  * instance, a pulse of 680 is less than QIR_PULSE_ZERO + QIR_PULSE_MARGIN so
  * will count as a zero bit.
  */
@@ -30,8 +30,7 @@
 #define QIR_LEAD_OUT QIR_PULSE * 10
 
 #define QIR_MAX_BITS 256
-#define QIR_BIT_BUFFERS QIR_MAX_BITS / 8
-#define QIR_TOP_BIT 0x80000000
+#define QIR_BUFFER_SIZE QIR_MAX_BITS / 8
 
 uint8_t calculateCRC(uint8_t *bitBuffers, uint16_t bits);
 

--- a/src/Quest_IR_Receiver.h
+++ b/src/Quest_IR_Receiver.h
@@ -7,6 +7,7 @@
 
 #include "./irlib2/IRLibRecvPCI.h"
 #include "Quest_IR_Format.h"
+#include "Quest_IR_BitWriter.h"
 
 // #define DEBUG_IR_RECEIVER
 
@@ -24,22 +25,20 @@ class Quest_IR_Receiver
 {
 public:
   DecodeState decodeState;
-  uint16_t bitsReceived;
+  uint8_t decodedBits[QIR_BUFFER_SIZE];
+  uint16_t decodedBitCount;
 
   void begin(uint8_t irPin);
   void enable();
   void disable();
   void enableBlink(bool enabled);
-  bool hasData();
-  uint16_t unreadBits();
-  uint32_t readBits(uint8_t bitsToRead);
+  bool hasSignal();
   void reset();
   void printRawSignal();
 
 private:
   IRrecvPCI receiver;
-  uint16_t nextBitPosition;
-  uint8_t bitBuffers[QIR_BIT_BUFFERS];
+  Quest_IR_BitWriter decodeWriter = Quest_IR_BitWriter(decodedBits, QIR_BUFFER_SIZE);
 
   void clearBuffer();
   void attemptDecode();

--- a/src/Quest_IR_Transmitter.h
+++ b/src/Quest_IR_Transmitter.h
@@ -7,23 +7,22 @@
 
 #include "irlib2/IRLibSendBase.h"
 #include "Quest_IR_Format.h"
+#include "Quest_IR_BitReader.h"
 
 // #define DEBUG_IR_TRANSMITTER
 
 class Quest_IR_Transmitter : public virtual IRsendBase
 {
 public:
+  uint8_t encodedBits[QIR_BUFFER_SIZE];
+
   void begin();
   void sendRawSignal(uint16_t *buffer, uint8_t length);
 
-  void clearBits();
-  bool addBits(uint32_t data, uint8_t bitsToSend);
-  bool sendBits();
+  bool sendBits(uint16_t encodedBitsToSend);
 
 private:
-  uint16_t nextBitPosition;
-  uint8_t bitBuffers[QIR_BIT_BUFFERS];
-
+  Quest_IR_BitReader encodeReader = Quest_IR_BitReader(encodedBits, QIR_BUFFER_SIZE);
   void sendSpace(bool one);
   void sendMark(bool one);
 };


### PR DESCRIPTION
 Wanted buffers exposed for easier integration with other libs. For instance Event lib could use BitWriter and BitReader to handle events over a network instead of being hardwired to use the IR library (which the current design would've forced).